### PR TITLE
ALS-728: Correction in offset convertion from Position

### DIFF
--- a/als-common/shared/src/main/scala/common/dtoTypes/Position.scala
+++ b/als-common/shared/src/main/scala/common/dtoTypes/Position.scala
@@ -8,14 +8,13 @@ import amf.core.parser.{Position => AmfPosition}
   *               represented as a string, the `character` value represents the gap between the
   *               `character` and `character + 1`.
   */
-
 case class Position(line: Int, column: Int) {
   def offset(text: String): Int = {
     def innerOffset(lines: List[String], currentLine: Int, currentOffset: Int): Int = lines match {
-      case Nil => currentOffset
-      case current :: Nil => Math.min(currentOffset + column, currentOffset + current.length - 1)
-      case current :: _ if currentLine == line => Math.min(currentOffset + column, currentOffset + current.length - 1)
-      case current :: rest => innerOffset(rest, currentLine + 1, currentOffset + current.length)
+      case Nil                                 => currentOffset
+      case current :: Nil                      => currentOffset + column
+      case current :: _ if currentLine == line => currentOffset + column
+      case current :: rest                     => innerOffset(rest, currentLine + 1, currentOffset + current.length)
     }
 
     if (line < 0 || column < 0) -1 else innerOffset(text.linesWithSeparators.toList, 0, 0)
@@ -37,21 +36,21 @@ object Position {
 
   def apply(offset: Int, text: String): Position = {
     def toPosition(count: Int, line: Int, lines: List[String]): Position = lines match {
-      case Nil => Position(line, 0)
-      case currentLine :: Nil => Position(line, Math.min(currentLine.length, offset - count))
+      case Nil                                                     => Position(line, 0)
+      case currentLine :: Nil                                      => Position(line, Math.min(currentLine.length, offset - count))
       case currentLine :: _ if offset - count < currentLine.length => Position(line, offset - count)
-      case current :: rest => toPosition(count + current.length, line + 1, rest)
+      case current :: rest                                         => toPosition(count + current.length, line + 1, rest)
     }
 
     offset match {
       case value if value < 0 => Position0
-      case _ => toPosition(0, 0, text.linesWithSeparators.toList)
+      case _                  => toPosition(0, 0, text.linesWithSeparators.toList)
     }
   }
 
-  def min(first: Position, second: Position): Position = if(second < first) second else first
+  def min(first: Position, second: Position): Position = if (second < first) second else first
 
-  def max(first: Position, second: Position): Position = if(second > first) second else first
+  def max(first: Position, second: Position): Position = if (second > first) second else first
 }
 
 object Position0 extends Position(0, 0)

--- a/als-server/jvm/src/main/scala/org/mulesoft/language/server/lsp4j/LanguageServerImpl.scala
+++ b/als-server/jvm/src/main/scala/org/mulesoft/language/server/lsp4j/LanguageServerImpl.scala
@@ -50,8 +50,8 @@ class LanguageServerImpl(val connection: ServerConnection,
     server.registerModule(new FindDeclarationModule())
     serverCapabilities.setDefinitionProvider(true)
 
-//    server.registerModule(new RenameModule())
-//    serverCapabilities.setRenameProvider(true)
+    server.registerModule(new RenameModule())
+    serverCapabilities.setRenameProvider(true)
 
     server
       .enableModule(ASTManagerModule.moduleId)
@@ -63,10 +63,6 @@ class LanguageServerImpl(val connection: ServerConnection,
       .flatMap(_ => server.enableModule(FindReferencesModule.moduleId))
       .flatMap(_ => server.enableModule(FindDeclarationModule.moduleId))
       .flatMap(_ => server.enableModule(RenameModule.moduleId))
-
-//    server.enableModule(FindReferencesModule.moduleId)
-//    server.enableModule(FindDeclarationModule.moduleId)
-//    server.enableModule(RenameModule.moduleId)
       .map(_ => new InitializeResult(serverCapabilities))
       .toJava
       .toCompletableFuture

--- a/als-server/shared/src/test/scala/org/mulesoft/helpers/ConversionsTest.scala
+++ b/als-server/shared/src/test/scala/org/mulesoft/helpers/ConversionsTest.scala
@@ -1,0 +1,43 @@
+package org.mulesoft.helpers
+
+import common.dtoTypes.Position
+import org.scalatest._
+
+class ConversionsTest extends FlatSpec {
+
+  "A position" should "maintain line and column equality through transformations" in {
+    val originalText = """#%RAML 1.0
+                         |
+                         |title: test API
+                         |
+                         |securitySchemes:
+                         |  ss:
+                         |    type:
+                         |
+                         |/endpoint: """
+
+    val pos = Position(6, 10)
+
+    val offset = pos.offset(originalText)
+
+    assert(pos == Position(offset, originalText))
+  }
+
+  it should "maintain offset equality through transformations" in {
+    val originalText = """#%RAML 1.0
+                         |
+                         |title: test API
+                         |
+                         |securitySchemes:
+                         |  ss:
+                         |    type:
+                         |
+                         |/endpoint: """
+
+    val offset = 62
+
+    val pos = Position(offset, originalText)
+
+    assert(offset == pos.offset(originalText))
+  }
+}


### PR DESCRIPTION
Se quita el tope por fin de linea en la conversion de [Position <-> Offset]
Este tope ocasionaba errores en la completion (por ejemplo en caso de estar escribiendo un key:value, al estar parado sobre key:* no se toma la posición del valor sino la del key, debido a que es lenght-1)

Dejo sujeto a revisión por miedo a estar afectando algo de forma colateral.

En el merge se puede reemplazar "current" por "_" ya que ya no se esta utilizando (dentro de innerOffset)