### PR TITLE
removed Environment() initializations

### DIFF
--- a/als-common/shared/src/main/scala/org/mulesoft/als/CompilerEnvironment.scala
+++ b/als-common/shared/src/main/scala/org/mulesoft/als/CompilerEnvironment.scala
@@ -4,7 +4,7 @@ import scala.concurrent.Future
 
 trait CompilerEnvironment[T, E] {
 
-  def modelBuiler(): ModelBuilder[T, E]
+  def modelBuilder(): ModelBuilder[T, E]
   def init(): Future[Unit]
 }
 

--- a/als-common/shared/src/main/scala/org/mulesoft/amfintegration/AmfInstance.scala
+++ b/als-common/shared/src/main/scala/org/mulesoft/amfintegration/AmfInstance.scala
@@ -46,11 +46,11 @@ class AmfInstance(plugins: Seq[AMFPlugin], platform: Platform, environment: Envi
     }
   }
 
-  override def modelBuiler(): ModelBuilder[AmfParseResult, Environment] = parserHelper
+  override def modelBuilder(): ModelBuilder[AmfParseResult, Environment] = parserHelper
 }
 
 object AmfInstance extends PlatformSecrets {
   def apply(environment: Environment): AmfInstance                     = apply(platform, environment)
   def apply(platform: Platform, environment: Environment): AmfInstance = new AmfInstance(Nil, platform, environment)
-  val default: AmfInstance                                             = new AmfInstance(Nil, platform, Environment())
+  val default: AmfInstance                                             = new AmfInstance(Nil, platform, Environment.empty())
 }

--- a/als-common/shared/src/main/scala/org/mulesoft/amfintegration/ParserHelper.scala
+++ b/als-common/shared/src/main/scala/org/mulesoft/amfintegration/ParserHelper.scala
@@ -65,16 +65,18 @@ class ParserHelper(val platform: Platform, amfInit: Future[Unit])
   }
 
   def indexDialect(url: String, content: Option[String]): Future[Unit] = {
-    val env = content.fold(Environment())(c => {
-      Environment().add(new ResourceLoader {
+    val env = content.fold(Environment.empty())(c => {
+      Environment
+        .empty()
+        .add(new ResourceLoader {
 
-        /** Fetch specified resource and return associated content. Resource should have benn previously accepted. */
-        override def fetch(resource: String): Future[Content] =
-          Future(new Content(c, resource))
+          /** Fetch specified resource and return associated content. Resource should have benn previously accepted. */
+          override def fetch(resource: String): Future[Content] =
+            Future(new Content(c, resource))
 
-        /** Accepts specified resource. */
-        override def accepts(resource: String): Boolean = resource == url
-      })
+          /** Accepts specified resource. */
+          override def accepts(resource: String): Boolean = resource == url
+        })
     })
 
     for {
@@ -118,7 +120,7 @@ class ParserHelper(val platform: Platform, amfInit: Future[Unit])
   }
 
   override def parse(uri: String): Future[AmfParseResult] =
-    parse(uri, Environment())
+    parse(uri, Environment.empty())
 }
 
 object ParserHelper {

--- a/als-server/jvm/src/main/scala/org/mulesoft/als/server/lsp4j/LanguageServerFactory.scala
+++ b/als-server/jvm/src/main/scala/org/mulesoft/als/server/lsp4j/LanguageServerFactory.scala
@@ -20,7 +20,6 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 // todo: standarize in one only converter (js and jvm) with generics
 class LanguageServerFactory(clientNotifier: ClientNotifier) extends PlatformSecrets {
-
   private var serialization: JvmSerializationProps               = EmptyJvmSerializationProps
   private var logger: Logger                                     = PrintLnLogger
   private var givenPlatform: Platform                            = platform

--- a/als-server/shared/src/main/scala/org/mulesoft/als/server/workspace/extract/ConfigReader.scala
+++ b/als-server/shared/src/main/scala/org/mulesoft/als/server/workspace/extract/ConfigReader.scala
@@ -13,11 +13,11 @@ trait ConfigReader {
 
   def readRoot(rootPath: String,
                platform: Platform,
-               environment: Environment = Environment(),
+               environment: Environment,
                logger: Logger): Future[Option[WorkspaceConf]] =
     readFile(appendFileToUri(rootPath).toAmfUri(platform), platform, environment).flatMap {
       case Some(content) =>
-        buildConfig(content, rootPath.toPath(platform), platform, logger) match {
+        buildConfig(content, rootPath.toPath(platform), platform, environment, logger) match {
           case Some(f) =>
             f.map(Some(_))
           case _ =>
@@ -46,5 +46,6 @@ trait ConfigReader {
   protected def buildConfig(content: String,
                             path: String,
                             platform: Platform,
+                            environment: Environment,
                             logger: Logger): Option[Future[WorkspaceConf]]
 }

--- a/als-structure/shared/src/test/scala/org/mulesoft/language/outline/test/OutlineTest.scala
+++ b/als-structure/shared/src/test/scala/org/mulesoft/language/outline/test/OutlineTest.scala
@@ -86,7 +86,7 @@ trait OutlineTest[T] extends AsyncFunSuite with FileAssertionTest with PlatformS
         env
       })
       .flatMap(env => {
-        compilerEnvironment.modelBuiler().parse(url, env).map(_.baseUnit)
+        compilerEnvironment.modelBuilder().parse(url, env).map(_.baseUnit)
       })
       .map {
         case amfUnit: BaseUnit =>

--- a/als-structure/shared/src/test/scala/org/mulesoft/language/outline/test/aml/DialectStructureTest.scala
+++ b/als-structure/shared/src/test/scala/org/mulesoft/language/outline/test/aml/DialectStructureTest.scala
@@ -1,5 +1,6 @@
 package org.mulesoft.language.outline.test.aml
 
+import amf.internal.environment.Environment
 import org.mulesoft.amfintegration.AmfInstance
 import org.mulesoft.language.outline.test.BaseStructureTest
 import org.scalatest.compatible.Assertion
@@ -10,7 +11,10 @@ class DialectStructureTest extends BaseStructureTest with DialectTest {
 
   def runTest(path: String, dialectPath: String, jsonPath: String): Future[Assertion] = {
     val fullDialectPath = filePath(dialectPath)
-    AmfInstance.default.parse(fullDialectPath).map(_.baseUnit).flatMap(_ => super.runTest(path, jsonPath))
+    AmfInstance(platform, Environment())
+      .parse(fullDialectPath)
+      .map(_.baseUnit)
+      .flatMap(_ => super.runTest(path, jsonPath))
   }
 
 }

--- a/als-suggestions/shared/src/main/scala/org/mulesoft/als/suggestions/client/Suggestions.scala
+++ b/als-suggestions/shared/src/main/scala/org/mulesoft/als/suggestions/client/Suggestions.scala
@@ -128,7 +128,8 @@ class Suggestions(platform: Platform,
 }
 
 object Suggestions extends PlatformSecrets {
-  val default = new Suggestions(platform, Environment(), new PlatformDirectoryResolver(platform), AmfInstance.default)
+  val default =
+    new Suggestions(platform, Environment.empty(), new PlatformDirectoryResolver(platform), AmfInstance.default)
 }
 
 trait SuggestionsHelper {

--- a/als-suggestions/shared/src/test/scala/org/mulesoft/als/suggestions/test/core/CoreTest.scala
+++ b/als-suggestions/shared/src/test/scala/org/mulesoft/als/suggestions/test/core/CoreTest.scala
@@ -5,6 +5,7 @@ import amf.core.unsafe.PlatformSecrets
 import amf.internal.environment.Environment
 import amf.internal.resource.ResourceLoader
 import amf.plugins.document.vocabularies.AMLPlugin
+import org.mulesoft.als.common.PlatformDirectoryResolver
 import org.mulesoft.als.suggestions.client.Suggestions
 import org.mulesoft.als.suggestions.interfaces.Syntax.YAML
 import org.mulesoft.als.suggestions.patcher.{ContentPatcher, PatchedContent}
@@ -86,8 +87,9 @@ trait CoreTest extends AsyncFunSuite with PlatformSecrets {
 
   def runTestForCustomDialect(path: String, dialectPath: String, originalSuggestions: Set[String]): Future[Assertion] = {
     val p             = filePath(dialectPath)
-    val configuration = AmfInstance.default
-    val s             = Suggestions.default
+    val env           = Environment()
+    val configuration = AmfInstance(platform, env)
+    val s             = new Suggestions(platform, env, new PlatformDirectoryResolver(platform), configuration)
     s.init(InitOptions.AllProfiles)
       .flatMap(_ => configuration.parse(p))
       .flatMap(_ =>

--- a/als-suggestions/shared/src/test/scala/org/mulesoft/als/suggestions/test/core/aml/BasicCoreTestsAML.scala
+++ b/als-suggestions/shared/src/test/scala/org/mulesoft/als/suggestions/test/core/aml/BasicCoreTestsAML.scala
@@ -1,7 +1,9 @@
 package org.mulesoft.als.suggestions.test.core.aml
 
 import amf.core.remote.Aml
+import amf.internal.environment.Environment
 import amf.plugins.document.vocabularies.AMLPlugin
+import org.mulesoft.als.common.PlatformDirectoryResolver
 import org.mulesoft.als.suggestions.CompletionsPluginHandler
 import org.mulesoft.als.suggestions.client.Suggestions
 import org.mulesoft.als.suggestions.test.core.{CoreTest, DummyPlugins}
@@ -30,8 +32,10 @@ class BasicCoreTestsAML extends CoreTest with DummyPlugins {
 
   test("Custom Plugins completion Dummy") {
     val p             = filePath("dialect.yaml")
-    val configuration = AmfInstance.default
-    val s             = Suggestions.default
+    val env           = Environment()
+    val configuration = AmfInstance(platform, env)
+    val s             = new Suggestions(platform, env, new PlatformDirectoryResolver(platform), configuration)
+
     for {
       dialect <- configuration.parse(p).map(_.baseUnit)
       _       <- s.init(InitOptions.AllProfiles)


### PR DESCRIPTION
Removed initializations from Environment (instead using Environment.empty), and changed config reader so that it uses the clients environment (instead of default = Environment() )