### PR TITLE
Added test suite for ObjectInTree

### DIFF
--- a/als-actions/shared/src/test/scala/org/mulesoft/als/actions/selection/SelectionRangeFinderTest.scala
+++ b/als-actions/shared/src/test/scala/org/mulesoft/als/actions/selection/SelectionRangeFinderTest.scala
@@ -16,9 +16,6 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 class SelectionRangeFinderTest extends AsyncFlatSpec with Matchers with PlatformSecrets {
 
-  override val executionContext: ExecutionContext =
-    scala.concurrent.ExecutionContext.Implicits.global
-
   it should "select the range on YAML map" in {
     val testUri                  = "file://test.yaml"
     val positions: Seq[Position] = Seq(Position(1, 8))

--- a/als-common/shared/src/test/resources/aml/dialects/dialect1.yaml
+++ b/als-common/shared/src/test/resources/aml/dialects/dialect1.yaml
@@ -1,0 +1,40 @@
+#%Dialect 1.0
+dialect: ObjectInTreeTest
+version: 1.0
+external:
+  internal-ns: http://internal.namespace.com/
+documents:
+  root:
+    encodes: Root
+    declares:
+      decA: A
+
+nodeMappings:
+  Root:
+    classTerm: internal-ns.Root
+    mapping:
+      x:
+        propertyTerm: internal-ns.x
+        range: A
+        allowMultiple: true
+      y:
+        propertyTerm: internal-ns.y
+        range: string
+        enum:
+          - b1
+          - b2
+          - b3
+      z:
+        propertyTerm: internal-ns.z
+        range: A
+        allowMultiple: true
+  A:
+    classTerm: internal-ns.A
+    mapping:
+      a1:
+        propertyTerm: internal-ns.a1
+        range: string
+      a2:
+        propertyTerm: internal-ns.a2
+        range: A
+        allowMultiple: true

--- a/als-common/shared/src/test/resources/aml/instances/instance1.yaml
+++ b/als-common/shared/src/test/resources/aml/instances/instance1.yaml
@@ -1,0 +1,29 @@
+#%ObjectInTreeTest 1.0
+decA:
+  testA:
+    a1: test a
+    a2:
+      - a1: sub a
+  testB:
+    a1: test b
+    a2:
+      - testA
+  testC:
+    a1: test c
+    a2:
+      - testA
+      - testB
+            #comment
+x:
+  - testA
+  - testB
+  - testC
+
+y: b1
+
+z:
+  - a1: value
+    a2:
+      - testC
+  - a1: value
+      #comment

--- a/als-common/shared/src/test/scala/org/mulesoft/als/common/ObjectInTreeTests.scala
+++ b/als-common/shared/src/test/scala/org/mulesoft/als/common/ObjectInTreeTests.scala
@@ -1,0 +1,174 @@
+package org.mulesoft.als.common
+
+import amf.core.parser
+import amf.core.unsafe.PlatformSecrets
+import amf.internal.environment.Environment
+import amf.plugins.document.vocabularies.metamodel.domain.DialectDomainElementModel
+import org.mulesoft.als.common.diff.FileAssertionTest
+import org.mulesoft.als.common.dtoTypes.Position
+import org.mulesoft.amfintegration.AmfInstance
+import org.scalatest.{Assertion, AsyncFlatSpec, Matchers}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.{ExecutionContext, Future}
+
+class ObjectInTreeTests extends AsyncFlatSpec with PlatformSecrets with Matchers with FileAssertionTest {
+  override val executionContext: ExecutionContext =
+    scala.concurrent.ExecutionContext.Implicits.global
+  behavior of "Object in Tree finder"
+
+  private def runTest(pos: Position,
+                      expectedTypeIri: String,
+                      expectedPropertyTerm: Option[String]): Future[Assertion] =
+    objectInTree.map { fn =>
+      val tree = fn(pos.toAmfPosition)
+      expectedPropertyTerm.foreach { pt =>
+        val fieldEntry = tree.fieldEntry.map(_.field.toString())
+        fieldEntry should contain(pt)
+      }
+      expectedPropertyTerm match {
+        case Some(pt) =>
+          val fieldEntry = tree.fieldEntry.map(_.field.toString())
+          fieldEntry should contain(pt)
+        case None =>
+          tree.fieldEntry should be(None)
+      }
+      tree.obj.meta match {
+        case ddem: DialectDomainElementModel =>
+          ddem.typeIri should contain(expectedTypeIri)
+        case _ => fail("Not a DialectDomainElementModel")
+      }
+    }
+
+  it should "identify a correct Root" in {
+    val pos                  = Position(15, 0)
+    val expectedTypeIri      = "http://internal.namespace.com/Root"
+    val expectedPropertyTerm = None
+    runTest(pos, expectedTypeIri, expectedPropertyTerm)
+  }
+
+  it should "identify a correct Declaration (final)" in {
+    val pos                  = Position(15, 2)
+    val expectedTypeIri      = "http://internal.namespace.com/Root" // todo: fix case
+    val expectedPropertyTerm = None
+    runTest(pos, expectedTypeIri, expectedPropertyTerm)
+  }
+
+  it should "identify a correct property (final)" in {
+    val pos                  = Position(15, 6)
+    val expectedTypeIri      = "http://internal.namespace.com/A"
+    val expectedPropertyTerm = None
+
+    runTest(pos, expectedTypeIri, expectedPropertyTerm)
+  }
+
+  it should "identify a correct property value (final)" in {
+    val pos                  = Position(15, 8)
+    val expectedTypeIri      = "http://internal.namespace.com/A"
+    val expectedPropertyTerm = None
+
+    runTest(pos, expectedTypeIri, expectedPropertyTerm)
+  }
+
+  it should "identify a single child" in {
+    val pos                  = Position(21, 4)
+    val expectedTypeIri      = "http://internal.namespace.com/Root"
+    val expectedPropertyTerm = Some("http://internal.namespace.com/y")
+
+    runTest(pos, expectedTypeIri, expectedPropertyTerm)
+  }
+
+  it should "identify a first property" in {
+    val pos                  = Position(3, 8)
+    val expectedTypeIri      = "http://internal.namespace.com/A"
+    val expectedPropertyTerm = Some("http://internal.namespace.com/a1")
+
+    runTest(pos, expectedTypeIri, expectedPropertyTerm)
+  }
+
+  it should "identify a middle property" in {
+    val pos                  = Position(4, 7)
+    val expectedTypeIri      = "http://internal.namespace.com/A"
+    val expectedPropertyTerm = Some("http://internal.namespace.com/a1")
+
+    runTest(pos, expectedTypeIri, expectedPropertyTerm)
+  }
+
+  it should "identify inside property value (array)" in {
+    val pos                  = Position(5, 8)
+    val expectedTypeIri      = "http://internal.namespace.com/A"
+    val expectedPropertyTerm = None
+
+    runTest(pos, expectedTypeIri, expectedPropertyTerm)
+  }
+
+  it should "identify inside property value (scalar)" in {
+    val pos                  = Position(5, 12)
+    val expectedTypeIri      = "http://internal.namespace.com/A"
+    val expectedPropertyTerm = Some("http://internal.namespace.com/a1")
+
+    runTest(pos, expectedTypeIri, expectedPropertyTerm)
+  }
+
+  it should "identify an array child" in {
+    val pos                  = Position(5, 13)
+    val expectedTypeIri      = "http://internal.namespace.com/A"
+    val expectedPropertyTerm = Some("http://internal.namespace.com/a1")
+
+    runTest(pos, expectedTypeIri, expectedPropertyTerm)
+  }
+
+  it should "identify root property with multiple values" in {
+    val pos                  = Position(23, 3)
+    val expectedTypeIri      = "http://internal.namespace.com/Root"
+    val expectedPropertyTerm = Some("http://internal.namespace.com/z")
+
+    runTest(pos, expectedTypeIri, expectedPropertyTerm)
+  }
+
+  it should "identify root property sublevel" in {
+    val pos                  = Position(24, 10)
+    val expectedTypeIri      = "http://internal.namespace.com/A"
+    val expectedPropertyTerm = Some("http://internal.namespace.com/a1")
+
+    runTest(pos, expectedTypeIri, expectedPropertyTerm)
+  }
+
+  it should "identify root property sublevel with array" in {
+    val pos                  = Position(26, 10)
+    val expectedTypeIri      = "http://internal.namespace.com/A"
+    val expectedPropertyTerm = None
+
+    runTest(pos, expectedTypeIri, expectedPropertyTerm)
+  }
+
+  it should "identify root property sublevel incomplete" in {
+    val pos                  = Position(28, 4)
+    val expectedTypeIri      = "http://internal.namespace.com/A"
+    val expectedPropertyTerm = None
+
+    runTest(pos, expectedTypeIri, expectedPropertyTerm)
+  }
+
+  private def uriTemplate(part: String) = s"file://als-common/shared/src/test/resources/aml/$part"
+
+  private val instance = AmfInstance(platform, Environment())
+  private val initDialects: Future[Unit] =
+    platform
+      .resolve(uriTemplate("dialects/dialect1.yaml"))
+      .map(_.stream.toString)
+      .flatMap(
+        dialectContent =>
+          instance
+            .init()
+            .andThen {
+              case _ => instance.alsAmlPlugin.registry.registerDialect(dialectContent)
+          })
+
+  private val objectInTree: Future[parser.Position => ObjectInTree] = for {
+    _  <- initDialects
+    bu <- instance.parse(uriTemplate("instances/instance1.yaml"))
+  } yield {
+    ObjectInTreeBuilder.fromUnit(bu.baseUnit, _)
+  }
+}

--- a/als-common/shared/src/test/scala/org/mulesoft/als/common/dtoTypes/PositionRangeTest.scala
+++ b/als-common/shared/src/test/scala/org/mulesoft/als/common/dtoTypes/PositionRangeTest.scala
@@ -1,6 +1,5 @@
 package org.mulesoft.als.common.dtoTypes
 
-import org.mulesoft.als.common.dtoTypes.{Position, PositionRange}
 import org.scalatest.FunSuite
 
 class PositionRangeTest extends FunSuite {

--- a/als-common/shared/src/test/scala/org/mulesoft/als/common/dtoTypes/PositionTest.scala
+++ b/als-common/shared/src/test/scala/org/mulesoft/als/common/dtoTypes/PositionTest.scala
@@ -1,6 +1,5 @@
 package org.mulesoft.als.common.dtoTypes
 
-import org.mulesoft.als.common.dtoTypes.Position
 import org.scalatest.FunSuite
 
 class PositionTest extends FunSuite {


### PR DESCRIPTION
Added ObjectInTreeTests with some specific tests trying out different positions in a dialect instance and checking the obj/field entry found by ObjectInTree match the expected result
(still not fully proven and need to recheck some results to decide which is correct)