### PR TITLE
[POC]: Workspace Manager sync

### DIFF
--- a/adrs/server/0001-workspace-synchronization.md
+++ b/adrs/server/0001-workspace-synchronization.md
@@ -1,0 +1,28 @@
+# 1. Workspace synchronization
+
+Date: 2020-04-14
+
+## Status
+
+Accepted
+
+## Context
+
+Workspace instantiation and Unit parsing run in independent futures.
+This results in some edge cases where when removing or adding a workspace resulted on a unit being placed in the wrong workspace,
+due to the fact the workspace was not yet removed/added to the workspace content manager list in WorkspaceManager.
+
+### Example
+
+One of the adopters initializes als-server with a rootPath `file:///ws1/` Immediately after sending initialization message sends an `OPEN_FILE("file:///ws1/dialect.yaml")`.
+Futures may happen in the following order:
+- Starts to instance WCM for `file:///ws1/`
+- Starts parsing `file:///ws1/dialect.yaml`
+- Finishes parsing `file:///ws1/dialect.yaml` and saves the unit in the default workspace (because workspace `file:///ws1/` is not yet on the list)
+- Finishes instancing WCM `file:///ws1/` and adds it to the workspace list
+- Requests unit for `file:///ws1/dialect.yaml`, as the prefix `file:///ws1/` matches looks for the unit there, but the unit was saved on the default workspace so we get a UnitNotFoundException.
+
+## Decision
+
+- We will block WorkspaceManager when making changes to the workspace list, to wait for the latest changes to workspace list before parsing or getting a unit.
+- We will also block WCM from processing when doing this to prevent unnecessary parsing.

--- a/als-server/shared/src/main/scala/org/mulesoft/als/server/modules/ast/AstListener.scala
+++ b/als-server/shared/src/main/scala/org/mulesoft/als/server/modules/ast/AstListener.scala
@@ -54,3 +54,7 @@ object CLOSE_FILE extends NotificationKind("CLOSE_FILE")
 object CHANGE_CONFIG extends NotificationKind("CHANGE_CONFIG")
 
 object WORKSPACE_TERMINATED extends NotificationKind("WORKSPACE_TERMINATED")
+
+object BLOCK_WORKSPACE extends NotificationKind("BLOCK_WORKSPACE")
+
+object UNBLOCK_WORKSPACE extends NotificationKind("UNBLOCK_WORKSPACE")

--- a/als-server/shared/src/main/scala/org/mulesoft/als/server/modules/completion/SuggestionsManager.scala
+++ b/als-server/shared/src/main/scala/org/mulesoft/als/server/modules/completion/SuggestionsManager.scala
@@ -114,14 +114,18 @@ class SuggestionsManager(val editorEnvironment: TextDocumentContainer,
                                  position: Int,
                                  patchedContent: PatchedContent,
                                  uuid: String): Future[CompletionProvider] =
-    suggestions.buildProviderAsync(
-      patchedParse(text, uri, position, patchedContent, uuid),
-      position,
-      uri,
-      patchedContent,
-      snippetSupport,
-      workspace.getProjectRootOf(uri)
-    )
+    workspace
+      .getProjectRootOf(uri)
+      .flatMap(rootLocation => {
+        suggestions.buildProviderAsync(
+          patchedParse(text, uri, position, patchedContent, uuid),
+          position,
+          uri,
+          patchedContent,
+          snippetSupport,
+          rootLocation
+        )
+      })
 
   private def patchedParse(text: TextDocument,
                            uri: String,

--- a/als-server/shared/src/main/scala/org/mulesoft/als/server/modules/workspace/StagingArea.scala
+++ b/als-server/shared/src/main/scala/org/mulesoft/als/server/modules/workspace/StagingArea.scala
@@ -3,19 +3,13 @@ package org.mulesoft.als.server.modules.workspace
 import amf.internal.environment.Environment
 import org.mulesoft.als.common.SyncFunction
 import org.mulesoft.als.server.logger.Logger
-import org.mulesoft.als.server.modules.ast.{
-  BaseUnitListenerParams,
-  CHANGE_FILE,
-  CLOSE_FILE,
-  NotificationKind,
-  OPEN_FILE,
-  WORKSPACE_TERMINATED
-}
+import org.mulesoft.als.server.modules.ast._
 import org.mulesoft.als.server.textsync.EnvironmentProvider
 
 import scala.collection.mutable
 
 trait StagingArea[Parameter] extends SyncFunction {
+
   protected val pending: mutable.Map[String, Parameter] = mutable.Map.empty
 
   def enqueue(file: String, kind: Parameter): Unit =
@@ -61,6 +55,10 @@ class ParserStagingArea(environmentProvider: EnvironmentProvider, logger: Logger
   }
 
   override def shouldDie: Boolean = pending.values.toList.contains(WORKSPACE_TERMINATED)
+
+  def shouldBlock: Boolean = pending.values.toList.contains(BLOCK_WORKSPACE)
+
+  def shouldUnblock: Boolean = pending.values.toList.contains(UNBLOCK_WORKSPACE)
 
   def snapshot(): Snapshot = synchronized {
     val environment                              = environmentProvider.environmentSnapshot()

--- a/als-server/shared/src/main/scala/org/mulesoft/als/server/modules/workspace/StagingArea.scala
+++ b/als-server/shared/src/main/scala/org/mulesoft/als/server/modules/workspace/StagingArea.scala
@@ -21,6 +21,15 @@ trait StagingArea[Parameter] extends SyncFunction {
   def dequeue(files: Set[String]): Unit =
     sync(() => files.foreach(pending.remove))
 
+  def dequeue(file: String, param: Parameter): Unit = {
+    sync(() => {
+      pending.get(file) match {
+        case Some(p) if p equals param => pending.remove(file)
+        case _                         =>
+      }
+    })
+  }
+
   def dequeue(): (String, Parameter) =
     sync(() => {
       val r = pending.head

--- a/als-server/shared/src/main/scala/org/mulesoft/als/server/modules/workspace/StagingArea.scala
+++ b/als-server/shared/src/main/scala/org/mulesoft/als/server/modules/workspace/StagingArea.scala
@@ -21,14 +21,12 @@ trait StagingArea[Parameter] extends SyncFunction {
   def dequeue(files: Set[String]): Unit =
     sync(() => files.foreach(pending.remove))
 
-  def dequeue(file: String, param: Parameter): Unit = {
-    sync(() => {
+  def dequeue(file: String, p: Parameter): Unit =
+    sync(() =>
       pending.get(file) match {
-        case Some(p) if p equals param => pending.remove(file)
-        case _                         =>
-      }
+        case Some(param) if param equals p => pending.remove(file)
+        case _                             =>
     })
-  }
 
   def dequeue(): (String, Parameter) =
     sync(() => {

--- a/als-server/shared/src/main/scala/org/mulesoft/als/server/modules/workspace/TaskManagerState.scala
+++ b/als-server/shared/src/main/scala/org/mulesoft/als/server/modules/workspace/TaskManagerState.scala
@@ -2,6 +2,7 @@ package org.mulesoft.als.server.modules.workspace
 
 sealed abstract class TaskManagerState(state: String)
 
+object Blocked           extends TaskManagerState("BLOCKED")
 object Idle              extends TaskManagerState("IDLE")
 object ProcessingProject extends TaskManagerState("PROCESSING_PROJECT")
 object NotAvailable      extends TaskManagerState("UNAVAILABLE")

--- a/als-server/shared/src/main/scala/org/mulesoft/als/server/workspace/FutureLock.scala
+++ b/als-server/shared/src/main/scala/org/mulesoft/als/server/workspace/FutureLock.scala
@@ -2,10 +2,12 @@ package org.mulesoft.als.server.workspace
 
 import java.util.concurrent.atomic.AtomicBoolean
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{Future, Promise}
 
 class FutureLock() {
   private val lock = new AtomicBoolean(false)
+
+  private val queue: SynchronizedList[Job[_]] = SynchronizedList()
 
   private def tryBlock(): Unit =
     synchronized(() => {
@@ -18,13 +20,46 @@ class FutureLock() {
 
   def isBlocked: Boolean = lock.get()
 
-  def block(): Future[Unit] = {
+  def enqueue[T](fn: () => Future[T]): Future[T] = {
+    if (!isBlocked) {
+      fn()
+    } else {
+      val job = new Job(fn, this)
+      queue += job
+      job.promise.future
+    }
+  }
+
+  def enqueueBlocking[T](fn: () => Future[T]): Future[T] = {
+    for {
+      _ <- block()
+      r <- fn()
+    } yield {
+      release()
+      r
+    }
+  }
+
+  def enqueue[T](job: Job[T]): Future[T] =
+    enqueue(job.fn)
+
+  def block(): Future[Unit] =
     Future({
       tryBlock()
     })
-  }
 
-  def release(): Unit = {
-    lock.set(false)
-  }
+  def release(): Unit =
+    synchronized(() => {
+      lock.set(false)
+      queue.foreach(_.run())
+      queue.clear()
+    })
+
+}
+
+class Job[T](val fn: () => Future[T], val lock: FutureLock) {
+  val promise: Promise[T] = Promise()
+
+  def run(): Future[T] =
+    promise.completeWith(lock.enqueue(this)).future
 }

--- a/als-server/shared/src/main/scala/org/mulesoft/als/server/workspace/FutureLock.scala
+++ b/als-server/shared/src/main/scala/org/mulesoft/als/server/workspace/FutureLock.scala
@@ -1,0 +1,30 @@
+package org.mulesoft.als.server.workspace
+
+import java.util.concurrent.atomic.AtomicBoolean
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class FutureLock() {
+  private val lock = new AtomicBoolean(false)
+
+  private def tryBlock(): Unit =
+    synchronized(() => {
+      if (isBlocked) {
+        tryBlock()
+      } else {
+        lock.set(true)
+      }
+    })
+
+  def isBlocked: Boolean = lock.get()
+
+  def block(): Future[Unit] = {
+    Future({
+      tryBlock()
+    })
+  }
+
+  def release(): Unit = {
+    lock.set(false)
+  }
+}

--- a/als-server/shared/src/main/scala/org/mulesoft/als/server/workspace/SynchronizedList.scala
+++ b/als-server/shared/src/main/scala/org/mulesoft/als/server/workspace/SynchronizedList.scala
@@ -1,0 +1,45 @@
+package org.mulesoft.als.server.workspace
+
+import scala.collection.mutable.ListBuffer
+
+class SynchronizedList[T] {
+  private val internal: ListBuffer[T] = ListBuffer()
+
+  def filter(fn: T => Boolean): Seq[T] = internal.filter(fn)
+
+  def +=(item: T): SynchronizedList[T] = {
+    this.synchronized {
+      internal += item
+    }
+    this
+  }
+
+  def -=(item: T): SynchronizedList[T] = {
+    this.synchronized {
+      internal -= item
+    }
+    this
+  }
+
+  def clear(): SynchronizedList[T] = {
+    this.synchronized {
+      internal.clear()
+    }
+    this
+  }
+
+  def :+(item: T): Seq[T] = internal :+ item
+
+  def foreach[U](fn: T => U): Unit = internal.foreach(fn)
+
+  def forall(fn: T => Boolean): Boolean = internal.forall(fn)
+
+  def exists(fn: T => Boolean): Boolean = internal.exists(fn)
+
+  def find(fn: T => Boolean): Option[T] = internal.find(fn)
+
+}
+
+object SynchronizedList {
+  def apply[T]() = new SynchronizedList[T]
+}

--- a/als-server/shared/src/main/scala/org/mulesoft/als/server/workspace/UnitTaskManager.scala
+++ b/als-server/shared/src/main/scala/org/mulesoft/als/server/workspace/UnitTaskManager.scala
@@ -57,10 +57,10 @@ trait UnitTaskManager[UnitType, ResultUnit <: UnitWithNextReference, StagingArea
     state = newState
   }
 
-  private var current: Future[Unit] = Future.unit
-  private val isDisabled            = Promise[Unit]()
+  protected var current: Future[Unit] = Future.unit
+  private val isDisabled              = Promise[Unit]()
 
-  private def canProcess: Boolean = state == Idle && current.isCompleted
+  protected def canProcess: Boolean = state == Idle && current.isCompleted
 
   private def next(f: Future[Unit]): Future[Unit] =
     f.recoverWith({
@@ -76,7 +76,7 @@ trait UnitTaskManager[UnitType, ResultUnit <: UnitWithNextReference, StagingArea
           current = process()
       }
 
-  private def process(): Future[Unit] =
+  protected def process(): Future[Unit] =
     if (state == NotAvailable) throw new UnavailableTaskManagerException
     else if (stagingArea.shouldDie) disable()
     else if (stagingArea.hasPending) next(processTask())
@@ -94,7 +94,7 @@ trait UnitTaskManager[UnitType, ResultUnit <: UnitWithNextReference, StagingArea
     throw UnitNotFoundException(uri)
   }
 
-  private def goIdle(): Future[Unit] = synchronized {
+  protected def goIdle(): Future[Unit] = synchronized {
     changeState(Idle)
     Future.unit
   }

--- a/als-server/shared/src/main/scala/org/mulesoft/als/server/workspace/UnitWorkspaceManager.scala
+++ b/als-server/shared/src/main/scala/org/mulesoft/als/server/workspace/UnitWorkspaceManager.scala
@@ -7,7 +7,7 @@ import org.mulesoft.lsp.feature.link.DocumentLink
 import scala.concurrent.Future
 
 trait UnitWorkspaceManager {
-  def getProjectRootOf(uri: String): Option[String]
+  def getProjectRootOf(uri: String): Future[Option[String]]
   def getDocumentLinks(uri: String, uuid: String): Future[Seq[DocumentLink]]
 
   /** gets all Project document links */

--- a/als-server/shared/src/main/scala/org/mulesoft/als/server/workspace/WorkspaceManager.scala
+++ b/als-server/shared/src/main/scala/org/mulesoft/als/server/workspace/WorkspaceManager.scala
@@ -15,7 +15,6 @@ import org.mulesoft.lsp.feature.link.DocumentLink
 import org.mulesoft.lsp.feature.telemetry.TelemetryProvider
 import org.mulesoft.lsp.workspace.{DidChangeWorkspaceFoldersParams, ExecuteCommandParams}
 
-import java.util.UUID
 import java.util.concurrent.Semaphore
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
@@ -122,10 +121,9 @@ class WorkspaceManager(environmentProvider: EnvironmentProvider,
   }
 
   private def blockingWorkspaces[T](func: () => Future[T]): Future[Unit] = {
-    val uuid = UUID.randomUUID().toString
     logger.debug("Blocking workspaces", "WorkspaceManager", "blockingWorkspaces")
     val workspaces = (this.workspaces :+ defaultWorkspace).filterNot(_.isTerminated)
-    workspaces.foreach(wcm => wcm.stage(wcm.folder + uuid, BLOCK_WORKSPACE))
+    workspaces.foreach(wcm => wcm.stage(wcm.folder, BLOCK_WORKSPACE))
     logger.debug("Blocking workspaces - notification sent", "WorkspaceManager", "blockingWorkspaces")
     def blockedWorkspaces(fun: () => Future[Unit]): Future[Unit] = {
       Future

--- a/als-server/shared/src/main/scala/org/mulesoft/als/server/workspace/WorkspaceManager.scala
+++ b/als-server/shared/src/main/scala/org/mulesoft/als/server/workspace/WorkspaceManager.scala
@@ -42,7 +42,7 @@ class WorkspaceManager(environmentProvider: EnvironmentProvider,
     if (!lock.isBlocked) Future {
       findWorkspace(uri)
     } else {
-      getWorkspace(uri)
+      lock.enqueue(() => getWorkspace(uri))
     }
   }
 
@@ -270,41 +270,4 @@ class WorkspaceManager(environmentProvider: EnvironmentProvider,
   override def isInMainTree(uri: String): Boolean =
     findWorkspace(uri).isInMainTree(uri)
 
-  class SynchronizedList[T] {
-    private val internal: ListBuffer[T] = ListBuffer()
-
-    def filter(fn: T => Boolean): Seq[T] = internal.filter(fn)
-
-    def +=(item: T): SynchronizedList[T] = {
-      this.synchronized {
-        internal += item
-      }
-      this
-    }
-
-    def -=(item: T): SynchronizedList[T] = {
-      this.synchronized {
-        internal -= item
-      }
-      this
-    }
-
-    def clear(): SynchronizedList[T] = {
-      this.synchronized {
-        internal.clear()
-      }
-      this
-    }
-
-    def :+(item: T): Seq[T] = internal :+ item
-
-    def foreach[U](fn: T => U): Unit = internal.foreach(fn)
-
-    def forall(fn: T => Boolean): Boolean = internal.forall(fn)
-
-    def exists(fn: T => Boolean): Boolean = internal.exists(fn)
-
-    def find(fn: T => Boolean): Option[T] = internal.find(fn)
-
-  }
 }

--- a/als-server/shared/src/main/scala/org/mulesoft/als/server/workspace/command/DidChangeConfigurationCommandExecutor.scala
+++ b/als-server/shared/src/main/scala/org/mulesoft/als/server/workspace/command/DidChangeConfigurationCommandExecutor.scala
@@ -6,6 +6,7 @@ import org.mulesoft.als.server.workspace.WorkspaceManager
 import org.mulesoft.lsp.textsync.DidChangeConfigurationNotificationParams
 import org.yaml.model.{YMap, YSequence}
 
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 class DidChangeConfigurationCommandExecutor(val logger: Logger, wsc: WorkspaceManager)
@@ -23,8 +24,10 @@ class DidChangeConfigurationCommandExecutor(val logger: Logger, wsc: WorkspaceMa
     }
   }
 
-  override protected def runCommand(param: DidChangeConfigurationNotificationParams): Future[Unit] = {
-    val manager = wsc.getWorkspace(param.mainUri)
-    wsc.contentManagerConfiguration(manager, param.mainUri, param.dependencies, None)
-  }
+  override protected def runCommand(param: DidChangeConfigurationNotificationParams): Future[Unit] =
+    wsc
+      .getWorkspace(param.mainUri)
+      .flatMap(manager => {
+        wsc.contentManagerConfiguration(manager, param.mainUri, param.dependencies, None)
+      })
 }

--- a/als-server/shared/src/main/scala/org/mulesoft/als/server/workspace/command/DidChangeConfigurationCommandExecutor.scala
+++ b/als-server/shared/src/main/scala/org/mulesoft/als/server/workspace/command/DidChangeConfigurationCommandExecutor.scala
@@ -2,7 +2,6 @@ package org.mulesoft.als.server.workspace.command
 
 import amf.core.parser._
 import org.mulesoft.als.server.logger.Logger
-import org.mulesoft.als.server.modules.ast.CHANGE_CONFIG
 import org.mulesoft.als.server.workspace.WorkspaceManager
 import org.mulesoft.lsp.textsync.DidChangeConfigurationNotificationParams
 import org.yaml.model.{YMap, YSequence}
@@ -27,7 +26,5 @@ class DidChangeConfigurationCommandExecutor(val logger: Logger, wsc: WorkspaceMa
   override protected def runCommand(param: DidChangeConfigurationNotificationParams): Future[Unit] = {
     val manager = wsc.getWorkspace(param.mainUri)
     wsc.contentManagerConfiguration(manager, param.mainUri, param.dependencies, None)
-    manager.stage(param.mainUri, CHANGE_CONFIG)
-    Future.unit
   }
 }

--- a/als-server/shared/src/main/scala/org/mulesoft/als/server/workspace/command/DidFocusCommandExecutor.scala
+++ b/als-server/shared/src/main/scala/org/mulesoft/als/server/workspace/command/DidFocusCommandExecutor.scala
@@ -7,6 +7,7 @@ import org.yaml.model.YMap
 import amf.core.parser._
 import org.mulesoft.als.server.protocol.textsync.DidFocusParams
 
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 class DidFocusCommandExecutor(val logger: Logger, wsc: WorkspaceManager)
@@ -21,8 +22,6 @@ class DidFocusCommandExecutor(val logger: Logger, wsc: WorkspaceManager)
     }
   }
 
-  override protected def runCommand(param: DidFocusParams): Future[Unit] = {
-    wsc.getWorkspace(param.uri).stage(param.uri, FOCUS_FILE)
-    Future.unit
-  }
+  override protected def runCommand(param: DidFocusParams): Future[Unit] =
+    wsc.getWorkspace(param.uri).map(_.stage(param.uri, FOCUS_FILE))
 }


### PR DESCRIPTION
Synchronize Workspace Manager (WM) and Workspace Content Managers (WCM)

Considerations:
- Whenever making changes to the workspaces (WCM) we should:
    1) Prevent new tasks from being added to the WCMs (block WorkspaceManager from notifying)
    2) Finish everything that each WCM has in the staging area and block it to prevent further processing, including defaultWorkspace
    3) Make the changes required to the Workspaces
    4) Unblock WCMs and WM
    5) Queue blocked notifications onto the corresponding WCM
- Throughout this whole process getWorkspace method in WM will be blocked, in order to execute the requests after the changes to the Workspaces are done.