### PR TITLE
telemetry log cleanup

### DIFF
--- a/als-lsp/shared/src/main/scala/org/mulesoft/lsp/feature/telemetry/TelemetryProvider.scala
+++ b/als-lsp/shared/src/main/scala/org/mulesoft/lsp/feature/telemetry/TelemetryProvider.scala
@@ -102,7 +102,7 @@ trait TelemetryProvider {
     fn()
       .andThen {
         case _ =>
-          addTimedMessage(code, endType, s"$msg\n\ttook ${System.currentTimeMillis() - time} millis", uri, uuid)
+          addTimedMessage(code, endType, s"$msg \n\ttook ${System.currentTimeMillis() - time} millis", uri, uuid)
       }
   }
 }

--- a/als-server/shared/src/main/scala/org/mulesoft/als/server/modules/actions/CodeActionManager.scala
+++ b/als-server/shared/src/main/scala/org/mulesoft/als/server/modules/actions/CodeActionManager.scala
@@ -97,7 +97,7 @@ class CodeActionManager(allActions: Seq[CodeActionFactory],
 
       override protected def msg(params: CodeActionParams): String =
         s"""Requested code action for ${params.textDocument.uri} at ${params.range}
-           |availableActions: $usedActions
+           |availableActions: ${usedActions.size}
            |supports documentChanges: ${configuration.supportsDocumentChanges}""".stripMargin
 
       override protected def uri(params: CodeActionParams): String = params.textDocument.uri

--- a/als-server/shared/src/main/scala/org/mulesoft/als/server/workspace/UnitTaskManager.scala
+++ b/als-server/shared/src/main/scala/org/mulesoft/als/server/workspace/UnitTaskManager.scala
@@ -87,7 +87,7 @@ trait UnitTaskManager[UnitType, ResultUnit <: UnitWithNextReference, StagingArea
       None
     else Some(current.flatMap(_ => getUnit(uri)))
 
-  protected def fail(uri: String) = {
+  protected def fail(uri: String): Nothing = {
     log(s"StagingArea: $stagingArea")
     log(s"State: $state")
     log(s"Repo uris: ${repository.getAllFilesUris}")


### PR DESCRIPTION
si se te ocurre algun otro log/cleanup para hacer es mas que bienvenido
lo que toque aca es que cuando se concatenaba `\n\t` a la uri en vez de hacer el salto de linea aparecia como parte de la uri, y que el log de las actions utilizadas era interpretado como un stacktrace por todo el mundo, asi que simplemente logueo la cantida de activas ahora