### PR TITLE
ALS-1615 Custom Validation version controlled from dependencies.properties

### DIFF
--- a/als-node-client/node-package/package-lock.json
+++ b/als-node-client/node-package/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@aml-org/amf-custom-validator": {
-      "version": "0.1.0-SNAPSHOT.10",
-      "resolved": "https://registry.npmjs.org/@aml-org/amf-custom-validator/-/amf-custom-validator-0.1.0-SNAPSHOT.10.tgz",
-      "integrity": "sha512-XleDWGMfUSQaQZeKVTVa3tZDh9zNZ1KKpBTXBvT1ptHY8DUNwF9Xg6qKOoo0m+J8b3Bpq+A7kLI2qppGD1p44Q==",
+      "version": "0.1.0-SNAPSHOT.15",
+      "resolved": "https://registry.npmjs.org/@aml-org/amf-custom-validator/-/amf-custom-validator-0.1.0-SNAPSHOT.15.tgz",
+      "integrity": "sha512-q8HcOnbvHEgtlEcM+B0Q3Bw9IFAzFqIOo+tklyRPTSLGvuzdtKrGLRmmXg0XMkcHEYyfzLs1vwo9PvWUNHJYIQ==",
       "requires": {
         "pako": "^2.0.3"
       }

--- a/als-node-client/node-package/package.json
+++ b/als-node-client/node-package/package.json
@@ -14,8 +14,8 @@
     "als": "./dist/als-node-client.min.js"
   },
   "dependencies": {
+    "@aml-org/amf-custom-validator": "0.1.0-SNAPSHOT.15",
     "ajv": "6.5.2",
-    "@aml-org/amf-custom-validator": "0.1.0-SNAPSHOT.10",
     "vscode-jsonrpc": "6.0.0",
     "vscode-languageserver-protocol": "3.16.0"
   }

--- a/build.sbt
+++ b/build.sbt
@@ -24,6 +24,7 @@ lazy val workspaceDirectory: File =
   }
 
 val amfVersion = deps("amf")
+val amfCustomValidatorJSVersion = deps("amf.custom-validator.js")
 
 lazy val amfJVMRef = ProjectRef(workspaceDirectory / "amf", "apiContractJVM")
 lazy val amfJSRef = ProjectRef(workspaceDirectory / "amf", "apiContractJS")
@@ -174,6 +175,7 @@ lazy val server = crossProject(JSPlatform, JVMPlatform)
   )
   .jsSettings(
     installJsDependencies := {
+      Process(s"npm install @aml-org/amf-custom-validator@$amfCustomValidatorJSVersion", new File("./als-server/js/node-package")) #&&
       Process("npm install",     new File("./als-server/js/node-package")) !
     },
     test in Test := ((test in Test) dependsOn installJsDependencies).value,
@@ -207,10 +209,8 @@ lazy val nodeClient =  project
     mainClass in Compile := Some("org.mulesoft.als.nodeclient.Main"),
 
     npmIClient := {
-      Process(
-        "npm i",
-        new File("./als-node-client/node-package/")
-      ).!
+      Process(s"npm install @aml-org/amf-custom-validator@$amfCustomValidatorJSVersion", new File("./als-node-client/node-package/")) #&&
+      Process("npm i", new File("./als-node-client/node-package/")) !
     },
 
     test in Test := ((test in Test) dependsOn npmIClient).value,

--- a/dependencies.properties
+++ b/dependencies.properties
@@ -1,2 +1,3 @@
 version=4.2.0-SNAPSHOT
 amf=5.0.0-beta.3
+amf.custom-validator.js=0.1.0-SNAPSHOT.15


### PR DESCRIPTION
Read AMF Custom Validator dependency read from `dependencies.properties`.
This will synchronize the version of `@aml-org/amf-custom-validator` in both `als-server` and `als-node-client`