### PR TITLE
Build unit cache at project provider instead of return units, in orde…

### DIFF
--- a/als-common/shared/src/main/scala/org/mulesoft/amfintegration/amfconfiguration/ALSConfigurationState.scala
+++ b/als-common/shared/src/main/scala/org/mulesoft/amfintegration/amfconfiguration/ALSConfigurationState.scala
@@ -63,13 +63,7 @@ case class ALSConfigurationState(editorState: EditorConfigurationState,
   private def predefinedWithDialects: AMLConfiguration =
     dialects.foldLeft(AMLConfiguration.predefined())((c, d) => c.withDialect(d))
 
-  val cache: UnitCache = new UnitCache {
-    val map: Map[String, BaseUnit] = projectState.cache.map(bu => bu.location().getOrElse(bu.id) -> bu).toMap
-    override def fetch(url: String): Future[CachedReference] = map.get(url) match {
-      case Some(bu) => Future.successful(CachedReference(url, bu))
-      case _        => throw new Exception("Unit not found")
-    }
-  }
+  val cache: UnitCache = projectState.cache
 
   private def getAmlConfig(base: AMLConfiguration): AMLConfiguration = {
     val configuration = base

--- a/als-common/shared/src/main/scala/org/mulesoft/amfintegration/amfconfiguration/ProjectConfigurationState.scala
+++ b/als-common/shared/src/main/scala/org/mulesoft/amfintegration/amfconfiguration/ProjectConfigurationState.scala
@@ -3,16 +3,19 @@ package org.mulesoft.amfintegration.amfconfiguration
 import amf.aml.client.scala.model.document.Dialect
 import amf.apicontract.client.scala.AMFConfiguration
 import amf.core.client.scala.AMFParseResult
+import amf.core.client.scala.config.{CachedReference, UnitCache}
 import amf.core.client.scala.model.document.BaseUnit
 import amf.core.client.scala.resource.ResourceLoader
 import amf.core.client.scala.validation.AMFValidationResult
 import org.mulesoft.als.configuration.ProjectConfiguration
 import org.mulesoft.amfintegration.ValidationProfile
 
+import scala.concurrent.Future
+
 trait ProjectConfigurationState {
 
   def customSetUp(amfConfiguration: AMFConfiguration): AMFConfiguration = amfConfiguration
-  def cache: Seq[BaseUnit]
+  def cache: UnitCache
 
   val extensions: Seq[Dialect]
   val profiles: Seq[ValidationProfile]
@@ -23,7 +26,8 @@ trait ProjectConfigurationState {
 }
 
 case class EmptyProjectConfigurationState(folder: String) extends ProjectConfigurationState() {
-  override val cache: Seq[BaseUnit]                    = Seq.empty
+  override val cache: UnitCache = (url: String) =>
+    Future.failed(new Exception("NothingUnitCache doesn't have any cached units"))
   override val extensions: Seq[Dialect]                = Seq.empty
   override val profiles: Seq[ValidationProfile]        = Seq.empty
   override val config: ProjectConfiguration            = ProjectConfiguration.empty(folder)

--- a/als-node-client/node-package/package-lock.json
+++ b/als-node-client/node-package/package-lock.json
@@ -225,11 +225,12 @@
       }
     },
     "define-properties": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+      "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
       "requires": {
-        "object-keys": "^1.0.12"
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
       }
     },
     "des.js": {
@@ -280,9 +281,9 @@
       }
     },
     "es-abstract": {
-      "version": "1.19.3",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.3.tgz",
-      "integrity": "sha512-4axXLNovnMYf0+csS5rVnS5hLmV1ek+ecx9MuCjByL1E5Nn54avf6CHQxIjgQIHBnfX9AMxTRIy0q+Yu5J/fXA==",
+      "version": "1.19.5",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.5.tgz",
+      "integrity": "sha512-Aa2G2+Rd3b6kxEUKTF4TaW67czBLyAv3z7VOhYRU50YBx+bbsYZ9xQP4lMNazePuFlybXI0V4MruPos7qUo5fA==",
       "requires": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
@@ -373,9 +374,17 @@
       }
     },
     "has-bigints": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
-      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ=="
+    },
+    "has-property-descriptors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+      "requires": {
+        "get-intrinsic": "^1.1.1"
+      }
     },
     "has-symbols": {
       "version": "1.0.3",

--- a/als-server/shared/src/main/scala/org/mulesoft/als/server/modules/ManagersFactory.scala
+++ b/als-server/shared/src/main/scala/org/mulesoft/als/server/modules/ManagersFactory.scala
@@ -89,10 +89,10 @@ class WorkspaceManagerFactoryBuilder(clientNotifier: ClientNotifier,
     customValidationManager = customValidatorBuilder.map(validator =>
       new CustomValidationManager(telemetryManager, clientNotifier, logger, gatherer, validator))
     customValidationManager.foreach(resolutionDependencies += _)
+    projectDependencies += pdm
     resolutionDependencies += rdm
     projectDependencies += dm
-    projectDependencies += pdm
-    Seq(Some(dm), Some(pdm), Some(rdm), customValidationManager).flatten
+    Seq(pdm, dm, rdm) ++ customValidationManager
   }
 
   def filesInProjectManager(alsClientNotifier: AlsClientNotifier[_]): FilesInProjectManager = {

--- a/als-server/shared/src/main/scala/org/mulesoft/als/server/modules/completion/CompletionReferenceResolver.scala
+++ b/als-server/shared/src/main/scala/org/mulesoft/als/server/modules/completion/CompletionReferenceResolver.scala
@@ -2,6 +2,7 @@ package org.mulesoft.als.server.modules.completion
 
 import amf.aml.client.scala.model.document.Dialect
 import amf.core.client.scala.AMFParseResult
+import amf.core.client.scala.config.{CachedReference, UnitCache}
 import amf.core.client.scala.model.document.BaseUnit
 import amf.core.client.scala.resource.ResourceLoader
 import amf.core.client.scala.validation.AMFValidationResult
@@ -9,6 +10,8 @@ import org.mulesoft.als.configuration.ProjectConfiguration
 import org.mulesoft.amfintegration.AmfImplicits.BaseUnitImp
 import org.mulesoft.amfintegration.ValidationProfile
 import org.mulesoft.amfintegration.amfconfiguration.ProjectConfigurationState
+
+import scala.concurrent.Future
 
 case class CompletionReferenceResolver(extensions: Seq[Dialect],
                                        profiles: Seq[ValidationProfile],
@@ -18,7 +21,13 @@ case class CompletionReferenceResolver(extensions: Seq[Dialect],
                                        projectErrors: Seq[AMFValidationResult],
                                        bu: BaseUnit)
     extends ProjectConfigurationState {
-  override def cache: Seq[BaseUnit] = bu.flatRefs
+  override def cache: UnitCache = new UnitCache {
+    val map: Map[String, BaseUnit] = bu.flatRefs.map(bu => bu.location().getOrElse(bu.id) -> bu).toMap
+    override def fetch(url: String): Future[CachedReference] = map.get(url) match {
+      case Some(bu) => Future.successful(CachedReference(url, bu))
+      case _        => throw new Exception("Unit not found")
+    }
+  }
 }
 
 object CompletionReferenceResolver {

--- a/als-server/shared/src/main/scala/org/mulesoft/als/server/modules/diagnostic/ProjectDiagnosticManager.scala
+++ b/als-server/shared/src/main/scala/org/mulesoft/als/server/modules/diagnostic/ProjectDiagnosticManager.scala
@@ -32,7 +32,7 @@ class ProjectDiagnosticManager(override protected val telemetryProvider: Telemet
     })
   }
 
-  override def onNewAst(ast: BaseUnitListenerParams, uuid: String): Future[Unit] = Future {
+  override def onNewAst(ast: BaseUnitListenerParams, uuid: String): Future[Unit] = {
     if (ast.tree) {
       val uri                    = ast.parseResult.location
       val projectErrors          = ast.parseResult.context.state.projectState.projectErrors
@@ -44,6 +44,7 @@ class ProjectDiagnosticManager(override protected val telemetryProvider: Telemet
         uuid
       )
     }
+    Future.unit
   }
 
   override def onRemoveFile(uri: String): Unit = {}


### PR DESCRIPTION
…r to be hable to map locations for dependencies. Add project errors at diagnostic manager. Add test for absolutes paths error.