### PR TITLE
W-11934738: Add validation for uriParam and queryParam to be managed as StringShape in RAML

### DIFF
--- a/als-suggestions/shared/src/main/scala/org/mulesoft/als/suggestions/plugins/aml/webapi/raml/RamlParamsCompletionPlugin.scala
+++ b/als-suggestions/shared/src/main/scala/org/mulesoft/als/suggestions/plugins/aml/webapi/raml/RamlParamsCompletionPlugin.scala
@@ -38,7 +38,7 @@ abstract class RamlParamsCompletionPlugin(
       branchStack: Seq[AmfObject],
       typeFacetsCompletionPlugin: WebApiTypeFacetsCompletionPlugin
   ): Seq[RawSuggestion] = {
-    typeFacetsCompletionPlugin.resolveShape(param.schema, branchStack, Raml10TypesDialect()) ++ withOthers
+    typeFacetsCompletionPlugin.resolveShape(param.schema, branchStack, Raml10TypesDialect(), Some(typeFacetsCompletionPlugin.stringShapeNode)) ++ withOthers
   }
 
   private def isNotName(params: AmlCompletionRequest): Boolean = {

--- a/als-suggestions/shared/src/test/resources/test/raml08/by-directory/top-level/base-uri-parameter-with-prefix.raml
+++ b/als-suggestions/shared/src/test/resources/test/raml08/by-directory/top-level/base-uri-parameter-with-prefix.raml
@@ -1,0 +1,5 @@
+#%RAML 0.8
+baseUri: https://anUri/example/{parameter}/chatter
+baseUriParameters:
+  parameter:
+    m*

--- a/als-suggestions/shared/src/test/resources/test/raml08/by-directory/top-level/expected/base-uri-parameter-with-prefix.raml.json
+++ b/als-suggestions/shared/src/test/resources/test/raml08/by-directory/top-level/expected/base-uri-parameter-with-prefix.raml.json
@@ -1,0 +1,62 @@
+[
+  {
+    "label": "maxLength",
+    "kind": [],
+    "detail": "parameters",
+    "documentation": "maxLength",
+    "deprecated": [],
+    "preselect": [],
+    "sortText": "11maxLength",
+    "filterText": "maxLength: ",
+    "insertText": null,
+    "insertTextFormat": [
+      1
+    ],
+    "textEdit": {
+      "range": {
+        "start": {
+          "line": 4,
+          "character": 4
+        },
+        "end": {
+          "line": 4,
+          "character": 5
+        }
+      },
+      "newText": "maxLength: "
+    },
+    "additionalTextEdits": null,
+    "commitCharacters": null,
+    "command": null
+  },
+  {
+    "label": "minLength",
+    "kind": [],
+    "detail": "parameters",
+    "documentation": "minLength",
+    "deprecated": [],
+    "preselect": [],
+    "sortText": "11minLength",
+    "filterText": "minLength: ",
+    "insertText": null,
+    "insertTextFormat": [
+      1
+    ],
+    "textEdit": {
+      "range": {
+        "start": {
+          "line": 4,
+          "character": 4
+        },
+        "end": {
+          "line": 4,
+          "character": 5
+        }
+      },
+      "newText": "minLength: "
+    },
+    "additionalTextEdits": null,
+    "commitCharacters": null,
+    "command": null
+  }
+]

--- a/als-suggestions/shared/src/test/resources/test/raml08/by-directory/top-level/expected/base-uri-parameter.raml.json
+++ b/als-suggestions/shared/src/test/resources/test/raml08/by-directory/top-level/expected/base-uri-parameter.raml.json
@@ -150,6 +150,96 @@
     "command": null
   },
   {
+    "label": "maxLength",
+    "kind": [],
+    "detail": "parameters",
+    "documentation": "maxLength",
+    "deprecated": [],
+    "preselect": [],
+    "sortText": "11maxLength",
+    "filterText": "maxLength: ",
+    "insertText": null,
+    "insertTextFormat": [
+      1
+    ],
+    "textEdit": {
+      "range": {
+        "start": {
+          "line": 4,
+          "character": 4
+        },
+        "end": {
+          "line": 4,
+          "character": 4
+        }
+      },
+      "newText": "maxLength: "
+    },
+    "additionalTextEdits": null,
+    "commitCharacters": null,
+    "command": null
+  },
+  {
+    "label": "minLength",
+    "kind": [],
+    "detail": "parameters",
+    "documentation": "minLength",
+    "deprecated": [],
+    "preselect": [],
+    "sortText": "11minLength",
+    "filterText": "minLength: ",
+    "insertText": null,
+    "insertTextFormat": [
+      1
+    ],
+    "textEdit": {
+      "range": {
+        "start": {
+          "line": 4,
+          "character": 4
+        },
+        "end": {
+          "line": 4,
+          "character": 4
+        }
+      },
+      "newText": "minLength: "
+    },
+    "additionalTextEdits": null,
+    "commitCharacters": null,
+    "command": null
+  },
+  {
+    "label": "pattern",
+    "kind": [],
+    "detail": "parameters",
+    "documentation": "pattern",
+    "deprecated": [],
+    "preselect": [],
+    "sortText": "11pattern",
+    "filterText": "pattern: ",
+    "insertText": null,
+    "insertTextFormat": [
+      1
+    ],
+    "textEdit": {
+      "range": {
+        "start": {
+          "line": 4,
+          "character": 4
+        },
+        "end": {
+          "line": 4,
+          "character": 4
+        }
+      },
+      "newText": "pattern: "
+    },
+    "additionalTextEdits": null,
+    "commitCharacters": null,
+    "command": null
+  },
+  {
     "label": "repeat",
     "kind": [],
     "detail": "schemas",

--- a/als-suggestions/shared/src/test/resources/test/raml10/by-directory/top-level/base-uri-parameter-type-array-with-prefix.raml
+++ b/als-suggestions/shared/src/test/resources/test/raml10/by-directory/top-level/base-uri-parameter-type-array-with-prefix.raml
@@ -1,0 +1,12 @@
+#%RAML 1.0
+title: Serialization API
+
+/users:
+  description: All users
+  /{userIds}:
+    description: A specific user
+    uriParameters:
+      userIds:
+        description: A list of userIds
+        type: array
+        m*

--- a/als-suggestions/shared/src/test/resources/test/raml10/by-directory/top-level/base-uri-parameter-type-array.raml
+++ b/als-suggestions/shared/src/test/resources/test/raml10/by-directory/top-level/base-uri-parameter-type-array.raml
@@ -1,0 +1,12 @@
+#%RAML 1.0
+title: Serialization API
+
+/users:
+  description: All users
+  /{userIds}:
+    description: A specific user
+    uriParameters:
+      userIds:
+        description: A list of userIds
+        type: array
+        *

--- a/als-suggestions/shared/src/test/resources/test/raml10/by-directory/top-level/base-uri-parameter-with-prefix.raml
+++ b/als-suggestions/shared/src/test/resources/test/raml10/by-directory/top-level/base-uri-parameter-with-prefix.raml
@@ -1,0 +1,11 @@
+#%RAML 1.0
+title: Serialization API
+
+/users:
+  description: All users
+  /{userIds}:
+    description: A specific user
+    uriParameters:
+      userIds:
+        description: A list of userIds
+        m*

--- a/als-suggestions/shared/src/test/resources/test/raml10/by-directory/top-level/expected/base-uri-parameter-type-array-with-prefix.raml.json
+++ b/als-suggestions/shared/src/test/resources/test/raml10/by-directory/top-level/expected/base-uri-parameter-type-array-with-prefix.raml.json
@@ -1,0 +1,62 @@
+[
+  {
+    "label": "maxItems",
+    "kind": [],
+    "detail": "unknown",
+    "documentation": "maxItems",
+    "deprecated": [],
+    "preselect": [],
+    "sortText": "11maxItems",
+    "filterText": "maxItems: ",
+    "insertText": null,
+    "insertTextFormat": [
+      1
+    ],
+    "textEdit": {
+      "range": {
+        "start": {
+          "line": 11,
+          "character": 8
+        },
+        "end": {
+          "line": 11,
+          "character": 9
+        }
+      },
+      "newText": "maxItems: "
+    },
+    "additionalTextEdits": null,
+    "commitCharacters": null,
+    "command": null
+  },
+  {
+    "label": "minItems",
+    "kind": [],
+    "detail": "unknown",
+    "documentation": "minItems",
+    "deprecated": [],
+    "preselect": [],
+    "sortText": "11minItems",
+    "filterText": "minItems: ",
+    "insertText": null,
+    "insertTextFormat": [
+      1
+    ],
+    "textEdit": {
+      "range": {
+        "start": {
+          "line": 11,
+          "character": 8
+        },
+        "end": {
+          "line": 11,
+          "character": 9
+        }
+      },
+      "newText": "minItems: "
+    },
+    "additionalTextEdits": null,
+    "commitCharacters": null,
+    "command": null
+  }
+]

--- a/als-suggestions/shared/src/test/resources/test/raml10/by-directory/top-level/expected/base-uri-parameter-type-array.raml.json
+++ b/als-suggestions/shared/src/test/resources/test/raml10/by-directory/top-level/expected/base-uri-parameter-type-array.raml.json
@@ -15,45 +15,15 @@
     "textEdit": {
       "range": {
         "start": {
-          "line": 5,
-          "character": 4
+          "line": 11,
+          "character": 8
         },
         "end": {
-          "line": 5,
-          "character": 4
+          "line": 11,
+          "character": 8
         }
       },
       "newText": "default: "
-    },
-    "additionalTextEdits": null,
-    "commitCharacters": null,
-    "command": null
-  },
-  {
-    "label": "description",
-    "kind": [],
-    "detail": "docs",
-    "documentation": "description",
-    "deprecated": [],
-    "preselect": [],
-    "sortText": "11description",
-    "filterText": "description: ",
-    "insertText": null,
-    "insertTextFormat": [
-      1
-    ],
-    "textEdit": {
-      "range": {
-        "start": {
-          "line": 5,
-          "character": 4
-        },
-        "end": {
-          "line": 5,
-          "character": 4
-        }
-      },
-      "newText": "description: "
     },
     "additionalTextEdits": null,
     "commitCharacters": null,
@@ -75,12 +45,12 @@
     "textEdit": {
       "range": {
         "start": {
-          "line": 5,
-          "character": 4
+          "line": 11,
+          "character": 8
         },
         "end": {
-          "line": 5,
-          "character": 4
+          "line": 11,
+          "character": 8
         }
       },
       "newText": "displayName: "
@@ -105,12 +75,12 @@
     "textEdit": {
       "range": {
         "start": {
-          "line": 5,
-          "character": 4
+          "line": 11,
+          "character": 8
         },
         "end": {
-          "line": 5,
-          "character": 4
+          "line": 11,
+          "character": 8
         }
       },
       "newText": "enum:\n  - "
@@ -135,12 +105,12 @@
     "textEdit": {
       "range": {
         "start": {
-          "line": 5,
-          "character": 4
+          "line": 11,
+          "character": 8
         },
         "end": {
-          "line": 5,
-          "character": 4
+          "line": 11,
+          "character": 8
         }
       },
       "newText": "example:\n  "
@@ -165,12 +135,12 @@
     "textEdit": {
       "range": {
         "start": {
-          "line": 5,
-          "character": 4
+          "line": 11,
+          "character": 8
         },
         "end": {
-          "line": 5,
-          "character": 4
+          "line": 11,
+          "character": 8
         }
       },
       "newText": "examples:\n  "
@@ -195,12 +165,12 @@
     "textEdit": {
       "range": {
         "start": {
-          "line": 5,
-          "character": 4
+          "line": 11,
+          "character": 8
         },
         "end": {
-          "line": 5,
-          "character": 4
+          "line": 11,
+          "character": 8
         }
       },
       "newText": "facets:\n  "
@@ -225,12 +195,12 @@
     "textEdit": {
       "range": {
         "start": {
-          "line": 5,
-          "character": 4
+          "line": 11,
+          "character": 8
         },
         "end": {
-          "line": 5,
-          "character": 4
+          "line": 11,
+          "character": 8
         }
       },
       "newText": "items:\n  "
@@ -240,14 +210,14 @@
     "command": null
   },
   {
-    "label": "maxLength",
+    "label": "maxItems",
     "kind": [],
-    "detail": "parameters",
-    "documentation": "maxLength",
+    "detail": "unknown",
+    "documentation": "maxItems",
     "deprecated": [],
     "preselect": [],
-    "sortText": "11maxLength",
-    "filterText": "maxLength: ",
+    "sortText": "11maxItems",
+    "filterText": "maxItems: ",
     "insertText": null,
     "insertTextFormat": [
       1
@@ -255,29 +225,29 @@
     "textEdit": {
       "range": {
         "start": {
-          "line": 5,
-          "character": 4
+          "line": 11,
+          "character": 8
         },
         "end": {
-          "line": 5,
-          "character": 4
+          "line": 11,
+          "character": 8
         }
       },
-      "newText": "maxLength: "
+      "newText": "maxItems: "
     },
     "additionalTextEdits": null,
     "commitCharacters": null,
     "command": null
   },
   {
-    "label": "minLength",
+    "label": "minItems",
     "kind": [],
-    "detail": "parameters",
-    "documentation": "minLength",
+    "detail": "unknown",
+    "documentation": "minItems",
     "deprecated": [],
     "preselect": [],
-    "sortText": "11minLength",
-    "filterText": "minLength: ",
+    "sortText": "11minItems",
+    "filterText": "minItems: ",
     "insertText": null,
     "insertTextFormat": [
       1
@@ -285,75 +255,15 @@
     "textEdit": {
       "range": {
         "start": {
-          "line": 5,
-          "character": 4
+          "line": 11,
+          "character": 8
         },
         "end": {
-          "line": 5,
-          "character": 4
+          "line": 11,
+          "character": 8
         }
       },
-      "newText": "minLength: "
-    },
-    "additionalTextEdits": null,
-    "commitCharacters": null,
-    "command": null
-  },
-  {
-    "label": "pattern",
-    "kind": [],
-    "detail": "parameters",
-    "documentation": "pattern",
-    "deprecated": [],
-    "preselect": [],
-    "sortText": "11pattern",
-    "filterText": "pattern: ",
-    "insertText": null,
-    "insertTextFormat": [
-      1
-    ],
-    "textEdit": {
-      "range": {
-        "start": {
-          "line": 5,
-          "character": 4
-        },
-        "end": {
-          "line": 5,
-          "character": 4
-        }
-      },
-      "newText": "pattern: "
-    },
-    "additionalTextEdits": null,
-    "commitCharacters": null,
-    "command": null
-  },
-  {
-    "label": "properties",
-    "kind": [],
-    "detail": "schemas",
-    "documentation": "properties",
-    "deprecated": [],
-    "preselect": [],
-    "sortText": "11properties",
-    "filterText": "properties:\n  ",
-    "insertText": null,
-    "insertTextFormat": [
-      1
-    ],
-    "textEdit": {
-      "range": {
-        "start": {
-          "line": 5,
-          "character": 4
-        },
-        "end": {
-          "line": 5,
-          "character": 4
-        }
-      },
-      "newText": "properties:\n  "
+      "newText": "minItems: "
     },
     "additionalTextEdits": null,
     "commitCharacters": null,
@@ -375,12 +285,12 @@
     "textEdit": {
       "range": {
         "start": {
-          "line": 5,
-          "character": 4
+          "line": 11,
+          "character": 8
         },
         "end": {
-          "line": 5,
-          "character": 4
+          "line": 11,
+          "character": 8
         }
       },
       "newText": "required: "
@@ -390,14 +300,14 @@
     "command": null
   },
   {
-    "label": "type",
+    "label": "uniqueItems",
     "kind": [],
-    "detail": "types and traits",
-    "documentation": "type",
+    "detail": "unknown",
+    "documentation": "uniqueItems",
     "deprecated": [],
     "preselect": [],
-    "sortText": "10type",
-    "filterText": "type: ",
+    "sortText": "11uniqueItems",
+    "filterText": "uniqueItems: ",
     "insertText": null,
     "insertTextFormat": [
       1
@@ -405,15 +315,15 @@
     "textEdit": {
       "range": {
         "start": {
-          "line": 5,
-          "character": 4
+          "line": 11,
+          "character": 8
         },
         "end": {
-          "line": 5,
-          "character": 4
+          "line": 11,
+          "character": 8
         }
       },
-      "newText": "type: "
+      "newText": "uniqueItems: "
     },
     "additionalTextEdits": null,
     "commitCharacters": null,
@@ -435,12 +345,12 @@
     "textEdit": {
       "range": {
         "start": {
-          "line": 5,
-          "character": 4
+          "line": 11,
+          "character": 8
         },
         "end": {
-          "line": 5,
-          "character": 4
+          "line": 11,
+          "character": 8
         }
       },
       "newText": "xml:\n  "

--- a/als-suggestions/shared/src/test/resources/test/raml10/by-directory/top-level/expected/base-uri-parameter-with-prefix.raml.json
+++ b/als-suggestions/shared/src/test/resources/test/raml10/by-directory/top-level/expected/base-uri-parameter-with-prefix.raml.json
@@ -1,0 +1,62 @@
+[
+  {
+    "label": "maxLength",
+    "kind": [],
+    "detail": "parameters",
+    "documentation": "maxLength",
+    "deprecated": [],
+    "preselect": [],
+    "sortText": "11maxLength",
+    "filterText": "maxLength: ",
+    "insertText": null,
+    "insertTextFormat": [
+      1
+    ],
+    "textEdit": {
+      "range": {
+        "start": {
+          "line": 10,
+          "character": 8
+        },
+        "end": {
+          "line": 10,
+          "character": 9
+        }
+      },
+      "newText": "maxLength: "
+    },
+    "additionalTextEdits": null,
+    "commitCharacters": null,
+    "command": null
+  },
+  {
+    "label": "minLength",
+    "kind": [],
+    "detail": "parameters",
+    "documentation": "minLength",
+    "deprecated": [],
+    "preselect": [],
+    "sortText": "11minLength",
+    "filterText": "minLength: ",
+    "insertText": null,
+    "insertTextFormat": [
+      1
+    ],
+    "textEdit": {
+      "range": {
+        "start": {
+          "line": 10,
+          "character": 8
+        },
+        "end": {
+          "line": 10,
+          "character": 9
+        }
+      },
+      "newText": "minLength: "
+    },
+    "additionalTextEdits": null,
+    "commitCharacters": null,
+    "command": null
+  }
+]

--- a/als-suggestions/shared/src/test/resources/test/raml10/by-directory/top-level/expected/query-parameter-with-prefix.raml.json
+++ b/als-suggestions/shared/src/test/resources/test/raml10/by-directory/top-level/expected/query-parameter-with-prefix.raml.json
@@ -1,0 +1,62 @@
+[
+  {
+    "label": "maxLength",
+    "kind": [],
+    "detail": "parameters",
+    "documentation": "maxLength",
+    "deprecated": [],
+    "preselect": [],
+    "sortText": "11maxLength",
+    "filterText": "maxLength: ",
+    "insertText": null,
+    "insertTextFormat": [
+      1
+    ],
+    "textEdit": {
+      "range": {
+        "start": {
+          "line": 12,
+          "character": 8
+        },
+        "end": {
+          "line": 12,
+          "character": 9
+        }
+      },
+      "newText": "maxLength: "
+    },
+    "additionalTextEdits": null,
+    "commitCharacters": null,
+    "command": null
+  },
+  {
+    "label": "minLength",
+    "kind": [],
+    "detail": "parameters",
+    "documentation": "minLength",
+    "deprecated": [],
+    "preselect": [],
+    "sortText": "11minLength",
+    "filterText": "minLength: ",
+    "insertText": null,
+    "insertTextFormat": [
+      1
+    ],
+    "textEdit": {
+      "range": {
+        "start": {
+          "line": 12,
+          "character": 8
+        },
+        "end": {
+          "line": 12,
+          "character": 9
+        }
+      },
+      "newText": "minLength: "
+    },
+    "additionalTextEdits": null,
+    "commitCharacters": null,
+    "command": null
+  }
+]

--- a/als-suggestions/shared/src/test/resources/test/raml10/by-directory/top-level/expected/query-parameter.raml.json
+++ b/als-suggestions/shared/src/test/resources/test/raml10/by-directory/top-level/expected/query-parameter.raml.json
@@ -1,0 +1,362 @@
+[
+  {
+    "label": "default",
+    "kind": [],
+    "detail": "parameters",
+    "documentation": "default",
+    "deprecated": [],
+    "preselect": [],
+    "sortText": "11default",
+    "filterText": "default: ",
+    "insertText": null,
+    "insertTextFormat": [
+      1
+    ],
+    "textEdit": {
+      "range": {
+        "start": {
+          "line": 12,
+          "character": 8
+        },
+        "end": {
+          "line": 12,
+          "character": 8
+        }
+      },
+      "newText": "default: "
+    },
+    "additionalTextEdits": null,
+    "commitCharacters": null,
+    "command": null
+  },
+  {
+    "label": "displayName",
+    "kind": [],
+    "detail": "docs",
+    "documentation": "displayName",
+    "deprecated": [],
+    "preselect": [],
+    "sortText": "11displayName",
+    "filterText": "displayName: ",
+    "insertText": null,
+    "insertTextFormat": [
+      1
+    ],
+    "textEdit": {
+      "range": {
+        "start": {
+          "line": 12,
+          "character": 8
+        },
+        "end": {
+          "line": 12,
+          "character": 8
+        }
+      },
+      "newText": "displayName: "
+    },
+    "additionalTextEdits": null,
+    "commitCharacters": null,
+    "command": null
+  },
+  {
+    "label": "enum",
+    "kind": [],
+    "detail": "parameters",
+    "documentation": "enum",
+    "deprecated": [],
+    "preselect": [],
+    "sortText": "11enum",
+    "filterText": "enum:\n  - ",
+    "insertText": null,
+    "insertTextFormat": [
+      1
+    ],
+    "textEdit": {
+      "range": {
+        "start": {
+          "line": 12,
+          "character": 8
+        },
+        "end": {
+          "line": 12,
+          "character": 8
+        }
+      },
+      "newText": "enum:\n  - "
+    },
+    "additionalTextEdits": null,
+    "commitCharacters": null,
+    "command": null
+  },
+  {
+    "label": "examples",
+    "kind": [],
+    "detail": "docs",
+    "documentation": "examples",
+    "deprecated": [],
+    "preselect": [],
+    "sortText": "11examples",
+    "filterText": "examples:\n  ",
+    "insertText": null,
+    "insertTextFormat": [
+      1
+    ],
+    "textEdit": {
+      "range": {
+        "start": {
+          "line": 12,
+          "character": 8
+        },
+        "end": {
+          "line": 12,
+          "character": 8
+        }
+      },
+      "newText": "examples:\n  "
+    },
+    "additionalTextEdits": null,
+    "commitCharacters": null,
+    "command": null
+  },
+  {
+    "label": "facets",
+    "kind": [],
+    "detail": "unknown",
+    "documentation": "facets",
+    "deprecated": [],
+    "preselect": [],
+    "sortText": "11facets",
+    "filterText": "facets:\n  ",
+    "insertText": null,
+    "insertTextFormat": [
+      1
+    ],
+    "textEdit": {
+      "range": {
+        "start": {
+          "line": 12,
+          "character": 8
+        },
+        "end": {
+          "line": 12,
+          "character": 8
+        }
+      },
+      "newText": "facets:\n  "
+    },
+    "additionalTextEdits": null,
+    "commitCharacters": null,
+    "command": null
+  },
+  {
+    "label": "items",
+    "kind": [],
+    "detail": "schemas",
+    "documentation": "items",
+    "deprecated": [],
+    "preselect": [],
+    "sortText": "11items",
+    "filterText": "items:\n  ",
+    "insertText": null,
+    "insertTextFormat": [
+      1
+    ],
+    "textEdit": {
+      "range": {
+        "start": {
+          "line": 12,
+          "character": 8
+        },
+        "end": {
+          "line": 12,
+          "character": 8
+        }
+      },
+      "newText": "items:\n  "
+    },
+    "additionalTextEdits": null,
+    "commitCharacters": null,
+    "command": null
+  },
+  {
+    "label": "maxLength",
+    "kind": [],
+    "detail": "parameters",
+    "documentation": "maxLength",
+    "deprecated": [],
+    "preselect": [],
+    "sortText": "11maxLength",
+    "filterText": "maxLength: ",
+    "insertText": null,
+    "insertTextFormat": [
+      1
+    ],
+    "textEdit": {
+      "range": {
+        "start": {
+          "line": 12,
+          "character": 8
+        },
+        "end": {
+          "line": 12,
+          "character": 8
+        }
+      },
+      "newText": "maxLength: "
+    },
+    "additionalTextEdits": null,
+    "commitCharacters": null,
+    "command": null
+  },
+  {
+    "label": "minLength",
+    "kind": [],
+    "detail": "parameters",
+    "documentation": "minLength",
+    "deprecated": [],
+    "preselect": [],
+    "sortText": "11minLength",
+    "filterText": "minLength: ",
+    "insertText": null,
+    "insertTextFormat": [
+      1
+    ],
+    "textEdit": {
+      "range": {
+        "start": {
+          "line": 12,
+          "character": 8
+        },
+        "end": {
+          "line": 12,
+          "character": 8
+        }
+      },
+      "newText": "minLength: "
+    },
+    "additionalTextEdits": null,
+    "commitCharacters": null,
+    "command": null
+  },
+  {
+    "label": "pattern",
+    "kind": [],
+    "detail": "parameters",
+    "documentation": "pattern",
+    "deprecated": [],
+    "preselect": [],
+    "sortText": "11pattern",
+    "filterText": "pattern: ",
+    "insertText": null,
+    "insertTextFormat": [
+      1
+    ],
+    "textEdit": {
+      "range": {
+        "start": {
+          "line": 12,
+          "character": 8
+        },
+        "end": {
+          "line": 12,
+          "character": 8
+        }
+      },
+      "newText": "pattern: "
+    },
+    "additionalTextEdits": null,
+    "commitCharacters": null,
+    "command": null
+  },
+  {
+    "label": "properties",
+    "kind": [],
+    "detail": "schemas",
+    "documentation": "properties",
+    "deprecated": [],
+    "preselect": [],
+    "sortText": "11properties",
+    "filterText": "properties:\n  ",
+    "insertText": null,
+    "insertTextFormat": [
+      1
+    ],
+    "textEdit": {
+      "range": {
+        "start": {
+          "line": 12,
+          "character": 8
+        },
+        "end": {
+          "line": 12,
+          "character": 8
+        }
+      },
+      "newText": "properties:\n  "
+    },
+    "additionalTextEdits": null,
+    "commitCharacters": null,
+    "command": null
+  },
+  {
+    "label": "type",
+    "kind": [],
+    "detail": "types and traits",
+    "documentation": "type",
+    "deprecated": [],
+    "preselect": [],
+    "sortText": "10type",
+    "filterText": "type: ",
+    "insertText": null,
+    "insertTextFormat": [
+      1
+    ],
+    "textEdit": {
+      "range": {
+        "start": {
+          "line": 12,
+          "character": 8
+        },
+        "end": {
+          "line": 12,
+          "character": 8
+        }
+      },
+      "newText": "type: "
+    },
+    "additionalTextEdits": null,
+    "commitCharacters": null,
+    "command": null
+  },
+  {
+    "label": "xml",
+    "kind": [],
+    "detail": "schemas",
+    "documentation": "xml",
+    "deprecated": [],
+    "preselect": [],
+    "sortText": "11xml",
+    "filterText": "xml:\n  ",
+    "insertText": null,
+    "insertTextFormat": [
+      1
+    ],
+    "textEdit": {
+      "range": {
+        "start": {
+          "line": 12,
+          "character": 8
+        },
+        "end": {
+          "line": 12,
+          "character": 8
+        }
+      },
+      "newText": "xml:\n  "
+    },
+    "additionalTextEdits": null,
+    "commitCharacters": null,
+    "command": null
+  }
+]

--- a/als-suggestions/shared/src/test/resources/test/raml10/by-directory/top-level/query-parameter-with-prefix.raml
+++ b/als-suggestions/shared/src/test/resources/test/raml10/by-directory/top-level/query-parameter-with-prefix.raml
@@ -1,0 +1,13 @@
+#%RAML 1.0
+title: GitHub API
+version: v3
+baseUri: https://api.github.com/{version}
+/users:
+  get:
+    description: Get a list of users
+    queryParameters:
+      page:
+        description: Specify the page that you want to retrieve
+        required:    true
+        example:     1
+        m*

--- a/als-suggestions/shared/src/test/resources/test/raml10/by-directory/top-level/query-parameter.raml
+++ b/als-suggestions/shared/src/test/resources/test/raml10/by-directory/top-level/query-parameter.raml
@@ -1,0 +1,13 @@
+#%RAML 1.0
+title: GitHub API
+version: v3
+baseUri: https://api.github.com/{version}
+/users:
+  get:
+    description: Get a list of users
+    queryParameters:
+      page:
+        description: Specify the page that you want to retrieve
+        required:    true
+        example:     1
+        *


### PR DESCRIPTION
W-11934738: Add validation for uriParam and queryParam to be managed as StringShape in RAML

I had to add a new validation for uriParameters with prefix because AMF is sending an UnresolvedShape instead of an unresolved NodeShape.

Add tests for queryParam and uriParam with prefix