### PR TITLE
W-12726960/Suggest_hashtag_slash: The hack here was capture when a suggestion is asked after an external fragment, change the prefix ("#/" was added), put a new flag to true (false is the default value) and make a recursive call to itself. Then using that flag inside PathSuggestor.scala tune in the RawSuggestion to get the CompletionItem that we want.

### DIFF
--- a/als-common/shared/src/main/scala/org/mulesoft/amfintegration/dialect/extensions/ApiExtensions.scala
+++ b/als-common/shared/src/main/scala/org/mulesoft/amfintegration/dialect/extensions/ApiExtensions.scala
@@ -1,0 +1,14 @@
+package org.mulesoft.amfintegration.dialect.extensions
+
+object ApiExtensions extends Enumeration {
+
+  val RAML = ".raml"
+  val YAML = ".yaml"
+  val JSON = ".json"
+
+  private val extensions = Seq(RAML, YAML, JSON)
+
+  def getValidExtensions: Seq[String] = extensions
+  def isValidExtension(extension: String): Boolean =
+    extensions.contains(extension.toLowerCase())
+}

--- a/als-suggestions/shared/src/main/scala/org/mulesoft/als/suggestions/plugins/aml/pathnavigation/PathNavigation.scala
+++ b/als-suggestions/shared/src/main/scala/org/mulesoft/als/suggestions/plugins/aml/pathnavigation/PathNavigation.scala
@@ -14,12 +14,13 @@ private[pathnavigation] case class PathNavigation(
     fileUri: String,
     navPath: String,
     prefix: String,
-    alsConfiguration: ALSConfigurationState
+    alsConfiguration: ALSConfigurationState,
+    flagFromExternalFragment: Boolean = false
 ) extends PathCompletion
     with PathSuggestor {
 
   override def suggest(): Future[Seq[RawSuggestion]] = {
-    nodes().map(nodes => buildSuggestions(nodes, prefix))
+    nodes().map(nodes => buildSuggestions(nodes, prefix, flagFromExternalFragment))
   }
 
   private def nodes(): Future[Seq[String]] = {

--- a/als-suggestions/shared/src/main/scala/org/mulesoft/als/suggestions/plugins/aml/pathnavigation/PathSuggestor.scala
+++ b/als-suggestions/shared/src/main/scala/org/mulesoft/als/suggestions/plugins/aml/pathnavigation/PathSuggestor.scala
@@ -1,6 +1,6 @@
 package org.mulesoft.als.suggestions.plugins.aml.pathnavigation
 
-import amf.core.client.scala.model.document.DeclaresModel
+import amf.core.client.scala.model.document.{BaseUnit, DeclaresModel}
 import org.mulesoft.als.suggestions.RawSuggestion
 import org.mulesoft.amfintegration.amfconfiguration.ALSConfigurationState
 
@@ -10,41 +10,75 @@ import scala.concurrent.Future
 trait PathSuggestor {
   def suggest(): Future[Seq[RawSuggestion]]
 
-  protected def buildSuggestions(names: Seq[String], prefix: String): Seq[RawSuggestion] =
-    names.map(n => RawSuggestion(s"${prevFromPrefix(prefix)}$n", isAKey = false))
+  protected def buildSuggestions(names: Seq[String], prefix: String, flag: Boolean = false): Seq[RawSuggestion] =
+    names.map(n =>
+      if (flag) buildRawSuggestionForExternalFragment(prefix, n)
+      else RawSuggestion(prevFromPrefix(prefix).concat(n), isAKey = false)
+    )
 
-  protected def prevFromPrefix(prefix: String): String =
+  protected def prevFromPrefix(prefix: String): String = {
     if (prefix.endsWith("/")) prefix
     else if (prefix.contains("/")) prefix.substring(0, prefix.lastIndexOf("/") + 1)
     else prefix + "/"
+  }
+
+  private def buildRawSuggestionForExternalFragment(prefix: String, n: String): RawSuggestion =
+    RawSuggestion(
+      value = prefix.concat(fixValue(n)),
+      isAKey = false,
+      category = "unknown",
+      mandatory = false,
+      displayText = Option(fixValue(n)),
+      Seq.empty
+    )
+
+  private def fixValue(prefix: String): String =
+    if (prefix.startsWith("/")) prefix.substring(1)
+    else prefix
 }
 
 object PathSuggestor {
-  def apply(fullUrl: String, prefix: String, alsConfiguration: ALSConfigurationState, targetClass: Option[String]): Future[PathSuggestor] = {
-    val (fileUri, navPath) =
+  def apply(
+      fullUrl: String,
+      prefix: String,
+      alsConfiguration: ALSConfigurationState,
+      targetClass: Option[String],
+      hackForComponent: Boolean = false
+  ): Future[PathSuggestor] = {
+    var (fileUri, navPath) =
       fullUrl.split("#").toList match {
         case head :: tail => (head, tail.headOption.getOrElse(""))
         case _            => ("", "")
       }
 
+    var newFileUri = fileUri
+    if (hackForComponent && navPath.isEmpty) {
+      newFileUri = fullUrl.concat(prefix)
+      navPath = "/"
+    }
+
     for {
       cached <-
-        try {
-          alsConfiguration.cache
-            .fetch(fileUri)
-            .map(f => Some(f.content))
-            .recoverWith { case _ =>
-              Future.successful(None)
-            }
-        } catch {
-          case _: Exception =>
-            Future.successful(None)
-        }
+        cacheFile(alsConfiguration, newFileUri)
     } yield {
       cached match {
-        case Some(schema: DeclaresModel) => DeclarablePathSuggestor(schema, prefix, targetClass)
-        case None                        => PathNavigation(fileUri, navPath, prefix, alsConfiguration)
+        case Some(schema: DeclaresModel) => DeclarablePathSuggestor(schema, prefix, targetClass, hackForComponent)
+        case None                        => PathNavigation(fileUri, navPath, prefix, alsConfiguration, hackForComponent)
       }
+    }
+  }
+
+  private def cacheFile(alsConfig: ALSConfigurationState, fileUri: String): Future[Option[BaseUnit]] = {
+    try {
+      alsConfig.cache
+        .fetch(fileUri)
+        .map(f => Some(f.content))
+        .recoverWith { case _ =>
+          Future.successful(None)
+        }
+    } catch {
+      case _: Exception =>
+        Future.successful(None)
     }
   }
 }

--- a/als-suggestions/shared/src/test/resources/test/oas30/oas-components/root-oas/api-ref-level1-without-hashtag-slash.yaml
+++ b/als-suggestions/shared/src/test/resources/test/oas30/oas-components/root-oas/api-ref-level1-without-hashtag-slash.yaml
@@ -1,0 +1,5 @@
+openapi: 3.0.0
+components:
+  schemas:
+    test:
+      $ref: "components.yaml*"

--- a/als-suggestions/shared/src/test/scala/org/mulesoft/als/suggestions/test/oas30/Oas30ComponentRefSuggestionTest.scala
+++ b/als-suggestions/shared/src/test/scala/org/mulesoft/als/suggestions/test/oas30/Oas30ComponentRefSuggestionTest.scala
@@ -83,6 +83,16 @@ class Oas30ComponentRefSuggestionTest extends AsyncFunSuite with BaseSuggestions
     }
   }
 
+  test("test oas3 including cached oas components should suggest the hashtag-slash wildcard (#/) with declared names") {
+    suggest("api-ref-level1-without-hashtag-slash.yaml", "components.yaml").map { ci =>
+      ci.length shouldBe 2
+      assert(ci.map(_.label).contains("components/schemas/mySchema1"))
+      assert(ci.map(_.filterText.get).contains("components.yaml#/components/schemas/mySchema1"))
+      assert(ci.map(_.label).contains("components/schemas/mySchema2"))
+      assert(ci.map(_.filterText.get).contains("components.yaml#/components/schemas/mySchema2"))
+    }
+  }
+
   private def suggest(api: String, componentName: String): Future[Seq[CompletionItem]] = {
     for {
       schema <- OASConfiguration


### PR DESCRIPTION
Signed-off-by: Federico Mansilla <mansilla.fede@gmail.com>
